### PR TITLE
Allow user to filter search by allergens

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,4 @@
 EXPO_PUBLIC_SUPABASE_URL=https://gyctjuntyyhoevdsgnmu.supabase.co
 EXPO_PUBLIC_SUPABASE_ANON_KEY=sb_publishable_wtScixA6XT9iVfLtrp_Rvg_Pmyfbve6
-EXPO_PUBLIC_BACKEND_URL=http://10.0.2.2:8080
+EXPO_PUBLIC_BACKEND_URL=http://swapsmart.us-east-2.elasticbeanstalk.com
+# http://10.0.2.2:8080 for local android emulator testing, else above URL is updated backend now hosted on AWS

--- a/app/results/[barcode].tsx
+++ b/app/results/[barcode].tsx
@@ -1,14 +1,15 @@
 // app/results/[barcode].tsx
 
+import { supabase } from "@/lib/supabase";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import React, { useEffect, useMemo, useState } from "react";
 import {
   ActivityIndicator,
   Pressable,
+  ScrollView,
   StyleSheet,
   Text,
   View,
-  ScrollView,
 } from "react-native";
 
 type AltProduct = {
@@ -26,7 +27,15 @@ const API_BASE_URL =
 
 // ---------- Backend ----------
 async function getAlternatives(barcode: string): Promise<AltProduct[]> {
-  const res = await fetch(`${API_BASE_URL}/api/alts/${encodeURIComponent(barcode)}`);
+  const { data: { session } } = await supabase.auth.getSession();
+  const token = session?.access_token;
+
+  const headers: Record<string, string> = {};
+  if (token) {
+    headers["Authorization"] = `Bearer ${token}`;
+  }
+
+  const res = await fetch(`${API_BASE_URL}/api/alts/${encodeURIComponent(barcode)}`, { headers });
   if (!res.ok) {
     const txt = await res.text();
     throw new Error(`Backend error ${res.status}: ${txt}`);

--- a/src/services/backendApi.ts
+++ b/src/services/backendApi.ts
@@ -1,11 +1,23 @@
 // src/services/backendApi.ts
 
+import { supabase } from "@/lib/supabase";
+
 const API_BASE_URL =
   process.env.EXPO_PUBLIC_BACKEND_URL ?? "http://10.0.2.2:8080"; // change if needed
 
 async function request<T>(path: string): Promise<T> {
   const url = `${API_BASE_URL}${path}`;
-  const res = await fetch(url);
+
+  // Get current session token if logged in
+  const { data: { session } } = await supabase.auth.getSession();
+  const token = session?.access_token;
+
+  const headers: Record<string, string> = {};
+  if (token) {
+    headers["Authorization"] = `Bearer ${token}`;
+  }
+
+  const res = await fetch(url, { headers });
 
   if (!res.ok) {
     const text = await res.text();


### PR DESCRIPTION
Changed results barcode page and BackendApi.ts to send bearer token in API call to backend, so backend has access to token and thus user info for that specific call. 

Only alternatives not containing allergens attached to logged-in user's profile will now appear.

If user is not logged in, usual wide range of alternatives displayed (limit 3). 

.env file now updated to call our hosted backend