### PR TITLE
Add call to save swaps endpoint in backend. Swaps appear in DB now

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
 EXPO_PUBLIC_SUPABASE_URL=https://gyctjuntyyhoevdsgnmu.supabase.co
 EXPO_PUBLIC_SUPABASE_ANON_KEY=sb_publishable_wtScixA6XT9iVfLtrp_Rvg_Pmyfbve6
-EXPO_PUBLIC_BACKEND_URL=http://swapsmart.us-east-2.elasticbeanstalk.com
+EXPO_PUBLIC_BACKEND_URL=http://10.0.2.2:8080
 # http://10.0.2.2:8080 for local android emulator testing, else above URL is updated backend now hosted on AWS

--- a/app/results/[barcode].tsx
+++ b/app/results/[barcode].tsx
@@ -111,6 +111,38 @@ export default function ResultsScreen() {
   const [scannedName, setScannedName] = useState<string | null>(null);
   const [scannedSugar, setScannedSugar] = useState<number | null>(null);
 
+  const saveSwap = async (barcode: string) => {
+    const { data: { session } } = await supabase.auth.getSession();
+    
+    if (!session) {
+        alert("Please log in to save swaps!");
+        return;
+    }
+
+    try {
+        const response = await fetch(`${API_BASE_URL}/api/swaps/save`, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                "Authorization": `Bearer ${session.access_token}`
+            },
+            body: JSON.stringify({
+                originalBarcode: bc,
+                alternativeBarcode: barcode
+            })
+        });
+
+        if (response.ok) {
+            alert("Swap saved!");
+        } else {
+            const error = await response.text();
+            alert(`Could not save: ${error}`);
+        }
+    } catch (e) {
+        alert("Network error saving swap.");
+    }
+  }
+
   const fetchAll = async () => {
     try {
       setLoading(true);
@@ -267,7 +299,7 @@ export default function ResultsScreen() {
                       <Pressable
                         style={[styles.btn]}
                         onPress={() => {
-                          alert('Saved')
+                          saveSwap(p.barcode)
                         }}
                       >
                         <Text style={[styles.sugarPillText, { color: 'black', }]}>


### PR DESCRIPTION
Closes issue #20 
Modified [barcode].tsx, so we call to backend endpoint to save swaps. 

For team: to test, host the backend locally, since it has not yet been updated on AWS.